### PR TITLE
Earn and settings fixes

### DIFF
--- a/app/src/main/java/com/example/localieapp/ConsumerDashboardActivity.kt
+++ b/app/src/main/java/com/example/localieapp/ConsumerDashboardActivity.kt
@@ -64,11 +64,19 @@ class ConsumerDashboardActivity : AppCompatActivity() {
 
                 bundle = Bundle().apply { putParcelableArrayList("coupons", listOfCoupons) }
 
-
+                val curFragmentName = intent.getStringExtra("Current_Fragment")
 
                 navigationView = findViewById(R.id.dashboard_tab_layout)
-                val tab = navigationView!!.getTabAt(1)
-                tab?.select()
+
+                if(curFragmentName == "Consumer_Profile"){
+                    val tab = navigationView!!.getTabAt(0)
+                    tab?.select()
+                }
+                else{
+                    val tab = navigationView!!.getTabAt(1)
+                    tab?.select()
+                }
+
 
                 navigationView!!.addOnTabSelectedListener(object : TabLayout.OnTabSelectedListener {
 
@@ -111,16 +119,29 @@ class ConsumerDashboardActivity : AppCompatActivity() {
                 })
 
                 // When we open the application first time
-                // the fragment should be shown to the user
-                // in this case it is home fragment
-                val fragment = ConsumerDealsFragment()
-                fragment.arguments = bundle
-                val earnFragment = ConsumerEarnFragment()
-                earnFragment.arguments = bundle
+                // the home fragment should be shown to the user
 
-                val fragmentTransaction = supportFragmentManager.beginTransaction()
-                fragmentTransaction.replace(R.id.content, fragment, "")
-                fragmentTransaction.commit()
+                // When navigating from the Settings Activity,
+                // the profile fragment should be shown
+
+                if(curFragmentName == "Consumer_Profile"){
+                    val fragment = ConsumerProfileFragment()
+                    val fragmentTransaction = supportFragmentManager.beginTransaction()
+                    fragmentTransaction.replace(R.id.content, fragment, "")
+                    fragmentTransaction.commit()
+                }
+                else{
+                    val fragment = ConsumerDealsFragment()
+                    fragment.arguments = bundle
+                    val earnFragment = ConsumerEarnFragment()
+                    earnFragment.arguments = bundle
+                    val fragmentTransaction = supportFragmentManager.beginTransaction()
+                    fragmentTransaction.replace(R.id.content, fragment, "")
+                    fragmentTransaction.commit()
+                }
+
+
+
             }
     }
 

--- a/app/src/main/java/com/example/localieapp/ConsumerDashboardActivity.kt
+++ b/app/src/main/java/com/example/localieapp/ConsumerDashboardActivity.kt
@@ -68,6 +68,7 @@ class ConsumerDashboardActivity : AppCompatActivity() {
 
                 navigationView = findViewById(R.id.dashboard_tab_layout)
 
+                // handles current tab selection when navigating from settings activity
                 if(curFragmentName == "Consumer_Profile"){
                     val tab = navigationView!!.getTabAt(0)
                     tab?.select()

--- a/app/src/main/java/com/example/localieapp/ConsumerSettingActivity.kt
+++ b/app/src/main/java/com/example/localieapp/ConsumerSettingActivity.kt
@@ -53,10 +53,11 @@ class ConsumerSettingActivity : AppCompatActivity() {
                 var user = User("null","null",arrayOf("null"),arrayOf("null"), "null","null","null","null")
             }
 
-        // TODO: back button should navigate to Consumer Profile Fragment in Dashboard Activity
         back?.setOnClickListener(View.OnClickListener {
         val mainIntent = Intent(this@ConsumerSettingActivity, ConsumerDashboardActivity::class.java)
         mainIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+        // using putExtra, we can specify which fragment in the Dashboard Activity to navigate to
+        mainIntent.putExtra("Current_Fragment", "Consumer_Profile")
         startActivity(mainIntent)
         })
 


### PR DESCRIPTION
Settings page used to redirect to the consumer deals page, and now correctly takes the user to the profile page. This fix implements navigation from an activity to a specific fragment within a different activity, which we hadn't done before. We should use the putExtra() function as the standard going forward